### PR TITLE
Instantiate IterateRepository and rename some classes

### DIFF
--- a/iterate/src/main/java/com/iteratehq/iterate/Iterate.kt
+++ b/iterate/src/main/java/com/iteratehq/iterate/Iterate.kt
@@ -26,13 +26,21 @@ object Iterate {
     @JvmStatic
     fun init(context: Context, apiKey: String) {
         iterateRepository = DefaultIterateRepository(context.applicationContext)
-        // TODO: initIdentify
         // TODO: initSendEvent
     }
 
+    /**
+     * TODO: add explanation
+     *
+     * @throws IllegalStateException TODO: add explanation
+     */
+    @Throws(IllegalStateException::class)
     @JvmStatic
     fun identify(userTraits: UserTraits) {
-        // TODO: Save userTraits into storage using repository
+        if (!::iterateRepository.isInitialized) {
+            throw IllegalStateException("Error calling Iterate.identify(). Make sure you call Iterate.init() before calling identify, see README for details")
+        }
+        iterateRepository.setUserTraits(userTraits)
     }
 
     /**
@@ -41,17 +49,29 @@ object Iterate {
      */
     @JvmStatic
     fun reset() {
-        // TODO: clear storage and all caches, except the companyAuthToken
         // Only clear the storage if it has been initialized. This allows the reset
-        // method to be called before Init, giving consumers of the SDK more flexibility.
+        // method to be called before Init, giving consumers of the SDK more flexibility
+        if (::iterateRepository.isInitialized) {
+            // Clear the storage and all caches, except for the companyAuthToken
+            iterateRepository.clearExceptCompanyAuthToken()
 
-        // TODO: set the company API key as the token
-        // Reset the api client to the company API key
+            // TODO: set the company API key as the token
+            // Reset the api client to the company API key
+        }
     }
 
+    /**
+     * TODO: add explanation
+     *
+     * @throws IllegalStateException TODO: add explanation
+     */
+    @Throws(IllegalStateException::class)
     @JvmStatic
     fun preview(surveyId: String) {
-        // TODO: store the surveyId inside IterateRepository (in-memory cache only)
+        if (!::iterateRepository.isInitialized) {
+            throw IllegalStateException("Error calling Iterate.preview(). Make sure you call Iterate.init() before calling preview, see README for details")
+        }
+        iterateRepository.setPreviewSurveyId(surveyId)
     }
 
     @JvmStatic

--- a/iterate/src/main/java/com/iteratehq/iterate/data/IterateRepository.kt
+++ b/iterate/src/main/java/com/iteratehq/iterate/data/IterateRepository.kt
@@ -8,6 +8,7 @@ import com.iteratehq.iterate.data.local.IterateSharedPrefs
 import com.iteratehq.iterate.model.UserTraits
 
 internal interface IterateRepository {
+    fun clearExceptCompanyAuthToken()
     fun getCompanyAuthToken(): String?
     fun getLastUpdated(): Long?
     fun getPreviewSurveyId(): String?
@@ -25,6 +26,13 @@ internal class DefaultIterateRepository @JvmOverloads internal constructor(
     private val iterateInMemoryStore: IterateInMemoryStore = DefaultIterateInMemoryStore(),
     private val iterateSharedPrefs: IterateSharedPrefs = DefaultIterateSharedPrefs(context.applicationContext),
 ) : IterateRepository {
+
+    override fun clearExceptCompanyAuthToken() {
+        val companyAuthToken = iterateInMemoryStore.getCompanyAuthToken()
+        iterateInMemoryStore.clear()
+        iterateSharedPrefs.clear()
+        companyAuthToken?.let { iterateInMemoryStore.setCompanyAuthToken(it) }
+    }
 
     override fun getCompanyAuthToken(): String? {
         return iterateInMemoryStore.getCompanyAuthToken()

--- a/iterate/src/main/java/com/iteratehq/iterate/data/local/IterateInMemoryStore.kt
+++ b/iterate/src/main/java/com/iteratehq/iterate/data/local/IterateInMemoryStore.kt
@@ -1,6 +1,7 @@
 package com.iteratehq.iterate.data.local
 
 internal interface IterateInMemoryStore {
+    fun clear()
     fun getCompanyAuthToken(): String?
     fun getPreviewSurveyId(): String?
     fun setCompanyAuthToken(companyAuthToken: String)
@@ -10,6 +11,11 @@ internal interface IterateInMemoryStore {
 internal class DefaultIterateInMemoryStore : IterateInMemoryStore {
     private var companyAuthToken: String? = null
     private var previewSurveyId: String? = null
+
+    override fun clear() {
+        companyAuthToken = null
+        previewSurveyId = null
+    }
 
     override fun getCompanyAuthToken(): String? {
         return companyAuthToken

--- a/iterate/src/main/java/com/iteratehq/iterate/data/local/IterateSharedPrefs.kt
+++ b/iterate/src/main/java/com/iteratehq/iterate/data/local/IterateSharedPrefs.kt
@@ -7,6 +7,7 @@ import com.google.gson.reflect.TypeToken
 import com.iteratehq.iterate.model.UserTraits
 
 internal interface IterateSharedPrefs {
+    fun clear()
     fun getLastUpdated(): Long?
     fun getUserAuthToken(): String?
     fun getUserTraits(): UserTraits?
@@ -21,6 +22,12 @@ internal class DefaultIterateSharedPrefs(
 
     private val prefs: SharedPreferences by lazy {
         context.getSharedPreferences(PREF_FILE, Context.MODE_PRIVATE)
+    }
+
+    override fun clear() {
+        prefs.edit()
+            .clear()
+            .apply()
     }
 
     override fun getLastUpdated(): Long? {


### PR DESCRIPTION
Instead of using dependency injection, we can either create a factory or set the default arguments on the constructor. I opt for the latter one as we don't have complex parameters there.