### PR TITLE
Fix crash on show survey screen when fragment manager is destroyed

### DIFF
--- a/iterate/src/main/java/com/iteratehq/iterate/Iterate.kt
+++ b/iterate/src/main/java/com/iteratehq/iterate/Iterate.kt
@@ -283,7 +283,13 @@ object Iterate {
                     dismissed(source, survey, progress)
                 }
             })
-            show(fragmentManager, null)
+            try {
+                if (!fragmentManager.isDestroyed) {
+                    show(fragmentManager, null)
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
 
         InteractionEvents.surveyDisplayed(survey)
@@ -307,7 +313,13 @@ object Iterate {
                     showSurvey(survey, responseId, fragmentManager)
                 }
             })
-            show(fragmentManager, null)
+            try {
+                if (!fragmentManager.isDestroyed) {
+                    show(fragmentManager, null)
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
 
         InteractionEvents.promptDisplayed(survey)


### PR DESCRIPTION
When we are setting Iterate's "When the survey is displayed" time to display after some seconds (for example 2) it leads to the following situation:

When a user clicks on some button (that closes the activity)  from the page where the survey must be shown the activity is destroyed and because of that Fragment Manager is destroyed as well, which is leading to a crash. 

The solution was to check if Fragment Manager is destroyed or not when showing the survey.
 
You can find the Stack trace below: 

Fatal Exception: java.lang.IllegalStateException: FragmentManager has been destroyed
       at androidx.fragment.app.FragmentManager.enqueueAction(FragmentManager.java:1635)
       at androidx.fragment.app.BackStackRecord.commitInternal(BackStackRecord.java:341)
       at androidx.fragment.app.BackStackRecord.commit(BackStackRecord.java:306)
       at androidx.fragment.app.DialogFragment.show(DialogFragment.java:262)
       at com.iteratehq.iterate.Iterate.showSurvey(Iterate.kt:286)
       at com.iteratehq.iterate.Iterate.showSurveyOrPrompt(Iterate.kt:264)
       at com.iteratehq.iterate.Iterate.access$showSurveyOrPrompt(Iterate.kt:35)
       at com.iteratehq.iterate.Iterate$sendEvent$2$onSuccess$3$1.invokeSuspend(Iterate.kt:199)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
       at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.java:570)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)