### PR TITLE
Always show bottom sheet for prompt in expanded state

### DIFF
--- a/iterate/src/main/java/com/iteratehq/iterate/view/PromptView.kt
+++ b/iterate/src/main/java/com/iteratehq/iterate/view/PromptView.kt
@@ -11,6 +11,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.view.ContextThemeWrapper
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.iteratehq.iterate.R
 import com.iteratehq.iterate.databinding.PromptViewBinding
@@ -42,6 +43,12 @@ class PromptView : BottomSheetDialogFragment() {
         // Inflate the layout using the cloned inflater, not the default inflater
         binding = PromptViewBinding.inflate(clonedInflater)
         return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val behavior = BottomSheetBehavior.from(requireView().parent as View)
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
The default behavior for a bottom sheet is to show in its collapsed state (peeking above the bottom of the screen and only partially visible) when in landscape mode.

![Screenshot_20221122_112457](https://user-images.githubusercontent.com/619997/203381588-8939a89a-cf6f-4a66-ba74-b277d36b5ad3.png)

This manually sets the state to expanded for the prompt view, so that we always see the entire view, even in landscape.

![Screenshot_20221122_112556](https://user-images.githubusercontent.com/619997/203381617-8524c523-6b3f-4e9a-b109-0002684c2be3.png)
