### PR TITLE
Fix missing close button

### DIFF
--- a/iterate/src/main/res/layout/prompt_view.xml
+++ b/iterate/src/main/res/layout/prompt_view.xml
@@ -15,9 +15,9 @@
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:background="@drawable/bg_button_close"
+        android:src="@drawable/ic_close"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_close" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/txt_prompt"


### PR DESCRIPTION
The legacy app:srcCompat doesn't appear to work in the latest Compose UI, it continues to work all the way down to SDK 21 so we should be good without it