### PR TITLE
Mark survey title field as optional

### DIFF
--- a/iterate/src/main/java/com/iteratehq/iterate/model/Survey.kt
+++ b/iterate/src/main/java/com/iteratehq/iterate/model/Survey.kt
@@ -11,7 +11,7 @@ data class Survey(
     val id: String,
     @SerializedName("company_id")
     val companyId: String,
-    val title: String,
+    val title: String?,
     val prompt: Prompt?,
     val color: String?,
     @SerializedName("color_dark")


### PR DESCRIPTION
A customer reported a crash where the stack trace contained this line:
```
Parameter specified as non-null is null: method com.iteratehq.iterate.model.Survey.<init>, parameter title
```

I was unable to reproduce the crash, but the title field on surveys is indeed optional, so the model should reflect that.