### PR TITLE
Fix ClassCastException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 `iterate-android` adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.6.2](https://github.com/iteratehq/iterate-android/releases/tag/v1.6.2)
+
+Released TBD.
+
+**Fixed**
+
+- Fixed ClassCastException crash when EventTraits are deserialized as HashMap after process restoration
+
 ## [1.6.1](https://github.com/iteratehq/iterate-android/releases/tag/v1.6.1)
 
 Released 2025-06-01.

--- a/iterate/src/main/java/com/iteratehq/iterate/view/SurveyView.kt
+++ b/iterate/src/main/java/com/iteratehq/iterate/view/SurveyView.kt
@@ -24,9 +24,9 @@ import com.iteratehq.iterate.databinding.SurveyViewBinding
 import com.iteratehq.iterate.model.EventMessageTypes
 import com.iteratehq.iterate.model.EventTraits
 import com.iteratehq.iterate.model.InteractionEventSource
-import com.iteratehq.iterate.model.StringToAnyMap
 import com.iteratehq.iterate.model.ProgressEventMessageData
 import com.iteratehq.iterate.model.ResponseEventMessageData
+import com.iteratehq.iterate.model.StringToAnyMap
 import com.iteratehq.iterate.model.Survey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -83,24 +83,25 @@ class SurveyView : DialogFragment() {
     private fun setupView() {
         val params = mutableListOf<String>()
         val authToken = arguments?.getString(AUTH_TOKEN)
-        
+
         // Safe handling of EventTraits deserialization to prevent ClassCastException
         val eventTraitsObj = arguments?.getSerializable(EVENT_TRAITS)
-        val eventTraits: EventTraits? = when (eventTraitsObj) {
-            is StringToAnyMap -> eventTraitsObj
-            is HashMap<*, *> -> {
-                // Convert HashMap to StringToAnyMap (happens after process death/restoration)
-                StringToAnyMap().apply {
-                    eventTraitsObj.forEach { (key, value) ->
-                        if (key is String && value != null) {
-                            this[key] = value
+        val eventTraits: EventTraits? =
+            when (eventTraitsObj) {
+                is StringToAnyMap -> eventTraitsObj
+                is HashMap<*, *> -> {
+                    // Convert HashMap to StringToAnyMap (happens after process death/restoration)
+                    StringToAnyMap().apply {
+                        eventTraitsObj.forEach { (key, value) ->
+                            if (key is String && value != null) {
+                                this[key] = value
+                            }
                         }
                     }
                 }
+                else -> null
             }
-            else -> null
-        }
-        
+
         val surveyTextFont = arguments?.getString(SURVEY_TEXT_FONT)
         val buttonFont = arguments?.getString(BUTTON_FONT)
 

--- a/iterate/src/main/java/com/iteratehq/iterate/view/SurveyView.kt
+++ b/iterate/src/main/java/com/iteratehq/iterate/view/SurveyView.kt
@@ -82,7 +82,24 @@ class SurveyView : DialogFragment() {
     private fun setupView() {
         val params = mutableListOf<String>()
         val authToken = arguments?.getString(AUTH_TOKEN)
-        val eventTraits = arguments?.getSerializable(EVENT_TRAITS) as EventTraits?
+        
+        // Safe handling of EventTraits deserialization to prevent ClassCastException
+        val eventTraitsObj = arguments?.getSerializable(EVENT_TRAITS)
+        val eventTraits: EventTraits? = when (eventTraitsObj) {
+            is StringToAnyMap -> eventTraitsObj
+            is HashMap<*, *> -> {
+                // Convert HashMap to StringToAnyMap (happens after process death/restoration)
+                StringToAnyMap().apply {
+                    eventTraitsObj.forEach { (key, value) ->
+                        if (key is String && value != null) {
+                            this[key] = value
+                        }
+                    }
+                }
+            }
+            else -> null
+        }
+        
         val surveyTextFont = arguments?.getString(SURVEY_TEXT_FONT)
         val buttonFont = arguments?.getString(BUTTON_FONT)
 

--- a/iterate/src/main/java/com/iteratehq/iterate/view/SurveyView.kt
+++ b/iterate/src/main/java/com/iteratehq/iterate/view/SurveyView.kt
@@ -24,6 +24,7 @@ import com.iteratehq.iterate.databinding.SurveyViewBinding
 import com.iteratehq.iterate.model.EventMessageTypes
 import com.iteratehq.iterate.model.EventTraits
 import com.iteratehq.iterate.model.InteractionEventSource
+import com.iteratehq.iterate.model.StringToAnyMap
 import com.iteratehq.iterate.model.ProgressEventMessageData
 import com.iteratehq.iterate.model.ResponseEventMessageData
 import com.iteratehq.iterate.model.Survey

--- a/iterate/src/test/java/com/iteratehq/iterate/view/SurveyViewDeserializationTest.kt
+++ b/iterate/src/test/java/com/iteratehq/iterate/view/SurveyViewDeserializationTest.kt
@@ -1,0 +1,115 @@
+package com.iteratehq.iterate.view
+
+import android.os.Bundle
+import com.iteratehq.iterate.model.StringToAnyMap
+import com.iteratehq.iterate.model.Survey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.HashMap
+
+@RunWith(RobolectricTestRunner::class)
+class SurveyViewDeserializationTest {
+
+    @Test
+    fun `test EventTraits deserialization handles HashMap correctly`() {
+        // Create a HashMap that simulates what Android returns after deserialization
+        val hashMap = HashMap<String, Any>().apply {
+            put("user_id", "12345")
+            put("is_premium", true)
+            put("account_age", 365)
+        }
+        
+        // Create a bundle and put the HashMap as Serializable
+        val bundle = Bundle().apply {
+            putSerializable("event_traits", hashMap)
+        }
+        
+        // Simulate the deserialization logic from setupView
+        val eventTraitsObj = bundle.getSerializable("event_traits")
+        val eventTraits = when (eventTraitsObj) {
+            is StringToAnyMap -> eventTraitsObj
+            is HashMap<*, *> -> {
+                StringToAnyMap().apply {
+                    eventTraitsObj.forEach { (key, value) ->
+                        if (key is String && value != null) {
+                            this[key] = value
+                        }
+                    }
+                }
+            }
+            else -> null
+        }
+        
+        // Verify the conversion worked correctly
+        assertNotNull(eventTraits)
+        assertTrue(eventTraits is StringToAnyMap)
+        assertEquals("12345", eventTraits?.get("user_id"))
+        assertEquals(true, eventTraits?.get("is_premium"))
+        assertEquals(365, eventTraits?.get("account_age"))
+    }
+    
+    @Test
+    fun `test EventTraits deserialization handles StringToAnyMap correctly`() {
+        // Create a StringToAnyMap
+        val stringToAnyMap = StringToAnyMap(
+            "user_id" to "12345",
+            "is_premium" to true,
+            "account_age" to 365
+        )
+        
+        // Create a bundle and put the StringToAnyMap as Serializable
+        val bundle = Bundle().apply {
+            putSerializable("event_traits", stringToAnyMap)
+        }
+        
+        // Simulate the deserialization logic from setupView
+        val eventTraitsObj = bundle.getSerializable("event_traits")
+        val eventTraits = when (eventTraitsObj) {
+            is StringToAnyMap -> eventTraitsObj
+            is HashMap<*, *> -> {
+                StringToAnyMap().apply {
+                    eventTraitsObj.forEach { (key, value) ->
+                        if (key is String && value != null) {
+                            this[key] = value
+                        }
+                    }
+                }
+            }
+            else -> null
+        }
+        
+        // Verify it's still the same object type
+        assertNotNull(eventTraits)
+        assertTrue(eventTraits is StringToAnyMap)
+        assertEquals("12345", eventTraits?.get("user_id"))
+        assertEquals(true, eventTraits?.get("is_premium"))
+        assertEquals(365, eventTraits?.get("account_age"))
+    }
+    
+    @Test
+    fun `test EventTraits deserialization handles null correctly`() {
+        val bundle = Bundle()
+        
+        val eventTraitsObj = bundle.getSerializable("event_traits")
+        val eventTraits = when (eventTraitsObj) {
+            is StringToAnyMap -> eventTraitsObj
+            is HashMap<*, *> -> {
+                StringToAnyMap().apply {
+                    eventTraitsObj.forEach { (key, value) ->
+                        if (key is String && value != null) {
+                            this[key] = value
+                        }
+                    }
+                }
+            }
+            else -> null
+        }
+        
+        // Should be null when no data is present
+        assertEquals(null, eventTraits)
+    }
+}


### PR DESCRIPTION
Fix ClassCastException when EventTraits are deserialized as HashMap after process restoration.

Android's `Bundle.getSerializable()` can return a plain `HashMap` when deserializing a `StringToAnyMap` (which is a `LinkedHashMap` type alias), especially after process death or configuration changes. This PR safely converts the `HashMap` back to `StringToAnyMap` to prevent crashes.